### PR TITLE
Fix errors and deprecations

### DIFF
--- a/personal/samba/class_sambaAccount.inc
+++ b/personal/samba/class_sambaAccount.inc
@@ -1070,7 +1070,7 @@ class sambaAccount extends plugin
         if ($this->sambaSID == "" || $this->orig_sambaDomainName != $this->sambaDomainName){
             $uidNumber= $this->uidNumber;
             while(TRUE){
-                $sid= $this->SID."-".($uidNumber*2 + $this->ridBase);
+                $sid= $this->SID."-".($uidNumber*2 + intval($this->ridBase));
                 $ldap->cd($this->config->current['BASE']);
                 $ldap->search("(sambaSID=$sid)", array("sambaSID"));
                 if ($ldap->count() == 0){

--- a/personal/samba/class_sambaLogonHours.inc
+++ b/personal/samba/class_sambaLogonHours.inc
@@ -6,7 +6,7 @@ class sambaLogonHours extends plugin
 
   var $sambaLogonHours = "";
   var $Matrix          = array();
-  var $timezone        = 0; 
+  public int $timezone = 0; 
   var $config;
   var $acl;
 
@@ -18,7 +18,7 @@ class sambaLogonHours extends plugin
 
     /* Get default timezone */
     $zone = timezone::get_default_timezone();
-    $this->timezone = $zone['value'];
+    $this->timezone = (int) $zone['value'];
 
     /* Convert to bin */
     $tmp = '';

--- a/personal/samba/class_sambaMungedDial.inc
+++ b/personal/samba/class_sambaMungedDial.inc
@@ -165,7 +165,7 @@ class sambaMungedDial
   			$paramValue= sambaMungedDial::strhex($paramValue.chr(0).chr(0));
   		} else {
   			$isString= FALSE;
-  		}  	
+  		}
   
   		/* Time parameter? */
   		if (in_array_strict($paramName, $this->timeParams)){

--- a/personal/samba/class_sambaMungedDial.inc
+++ b/personal/samba/class_sambaMungedDial.inc
@@ -106,14 +106,14 @@ class sambaMungedDial
 
   function genTime ($minutes)
   {
-  	$usec= (int) ($minutes * 60 * 1000);
+  	$usec= (intval($minutes) * 60 * 1000);
   	$src=  sprintf('%04x%04x', $usec & 0x0FFFF, ($usec & 0x0FFFF0000) >> 16);
   	return (sambaMungedDial::endian(substr($src, 0, 4)).sambaMungedDial::endian(substr($src, 4, 4)));
   }
 
   function readTime ($time)
   {
-  	$lo= substr($time, 0, 4);
+	$lo= substr($time, 0, 4);
   	$hi= substr($time, 4, 4);
   
   	$usecs= (hexdec(substr($lo, 2, 2)) * 256 + hexdec(substr($lo, 0, 2))) +

--- a/personal/samba/class_sambaMungedDial.inc
+++ b/personal/samba/class_sambaMungedDial.inc
@@ -113,7 +113,7 @@ class sambaMungedDial
 
   function readTime ($time)
   {
-	$lo= substr($time, 0, 4);
+  	$lo= substr($time, 0, 4);
   	$hi= substr($time, 4, 4);
   
   	$usecs= (hexdec(substr($lo, 2, 2)) * 256 + hexdec(substr($lo, 0, 2))) +
@@ -165,7 +165,7 @@ class sambaMungedDial
   			$paramValue= sambaMungedDial::strhex($paramValue.chr(0).chr(0));
   		} else {
   			$isString= FALSE;
-  		}
+  		}  	
   
   		/* Time parameter? */
   		if (in_array_strict($paramName, $this->timeParams)){

--- a/personal/samba/default/samba3.tpl
+++ b/personal/samba/default/samba3.tpl
@@ -340,7 +340,7 @@
                 {render acl=$sambaKickoffTimeACL}
                     <div class="input-field inline">
                         <input type="text" id="lang" value="{$lang}" hidden="true">
-                        <input type="text" id="sambaKickoffTime" name="sambaKickoffTime" class="datepicker" value="{$sambaKickoffTime}" style="width: 200px;">
+                        <input type="text" id="sambaKickoffTime" name="sambaKickoffTime" class="futureDatepicker" value="{$sambaKickoffTime}" style="width: 200px;">
                         <label for="sambaKickoffTime"></label>
                     </div>
                 {/render}


### PR DESCRIPTION
- "Account expires after" datepicker did only allow past dates
- Operand of type float|int to modulo (%%) operator is implicitly converted to int (deprecated in PHP 8.1)
- Fatal error when trying to multiplicate string with int