### PR TITLE
Fix false cb validations for connection, disconnection, idle

### DIFF
--- a/personal/samba/class_sambaMungedDial.inc
+++ b/personal/samba/class_sambaMungedDial.inc
@@ -304,7 +304,7 @@ class sambaMungedDial
   	$result= array();
   	if (session::get("js")){
   		foreach ($this->timeParams as $value) {
-  			if (!isset($this->ctx[$value]) || (isset($this->ctx[$value]) && $this->ctx[$value] == 0)) {
+  			if (!isset($this->ctx[$value]) || $this->ctx[$value] === '' || $this->ctx[$value] == 0) {
   				$result[$value."Mode"]= "disabled";
   			} else {
   				$result[$value."Mode"]= "";
@@ -545,7 +545,7 @@ class sambaMungedDial
   function getCtxMaxConnectionTimeF ()
   {
   	// Connection Time is 0 if disabled
-  	if (isset($this->ctx['CtxMaxConnectionTime']) && ($this->ctx['CtxMaxConnectionTime'] != 0)) {
+  	if (isset($this->ctx['CtxMaxConnectionTime']) && $this->ctx['CtxMaxConnectionTime'] !== '' && ($this->ctx['CtxMaxConnectionTime'] != 0)) {
   		$result= true;
   	} else {
   		$result= false;
@@ -566,7 +566,7 @@ class sambaMungedDial
   function getCtxMaxDisconnectionTimeF ()
   {
   	// Connection Time is 0 if disabled
-  	if (isset($this->ctx['CtxMaxDisconnectionTime']) && ($this->ctx['CtxMaxDisconnectionTime'] != 0)) {
+  	if (isset($this->ctx['CtxMaxDisconnectionTime']) && $this->ctx['CtxMaxDisconnectionTime'] !== '' && ($this->ctx['CtxMaxDisconnectionTime'] != 0)) {
   		$result= true;
   	} else {
   		$result= false;
@@ -587,7 +587,7 @@ class sambaMungedDial
   function getCtxMaxIdleTimeF ()
   {
   	// Connection Time is 0 if disabled
-  	if (isset($this->ctx['CtxMaxIdleTime']) && ($this->ctx['CtxMaxIdleTime'] != 0)) {
+  	if (isset($this->ctx['CtxMaxIdleTime']) && $this->ctx['CtxMaxIdleTime'] !== '' && ($this->ctx['CtxMaxIdleTime'] != 0)) {
   		$result= true;
   	} else {
   		$result= false;


### PR DESCRIPTION
Its the same problem as [#81 in gosa-core](https://github.com/gosa-project/gosa-core/pull/81)

New samba accounts are initialized like this

```
'CtxMaxConnectionTime' =>   	'',
'CtxMaxDisconnectionTime' =>	'',
'CtxMaxIdleTime' => 	      	'',
```

But the empty default values were falsely interpreted as an checked checkbox. Since PHP8 we need to explicetly check for an empty string cause 0 == "" was evaluated to true in PHP 7 but to false in PHP 8. See https://wiki.php.net/rfc/string_to_number_comparison.

The problem caused the checkboxes to be checked immediately upon creating a new Samba account, even though they should have been unchecked.